### PR TITLE
Add pos() function and generic CompileFast<T, TResult>()

### DIFF
--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/DecimalDotNetStandardMathContextTests.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/DecimalDotNetStandardMathContextTests.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand
 

--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/DotNetStandardMathContextTests.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/DotNetStandardMathContextTests.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand
 

--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests.Compile.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests.Compile.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.FastExpressionCompiler.Tests.Compilation;
 

--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Complex.Compile.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Complex.Compile.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.FastExpressionCompiler.Tests.Compilation;
 

--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Decimal.Compile.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Decimal.Compile.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.FastExpressionCompiler.Tests.Compilation;
 

--- a/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Number.Compile.cs
+++ b/MathEvaluation.FastExpressionCompiler.Tests/Compilation/MathExpressionTests_Number.Compile.cs
@@ -20,9 +20,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("10 / 3", 10 / 3)]
     [InlineData("-20", -20)]
     [InlineData("6 + -(4)", 6 + -(4))]
-    public void MathExpression_CompileThenInvoke_Int32_ExpectedValue(string mathString, int expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int32_ExpectedValue(string mathString, int expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<int>();
@@ -37,9 +37,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("4 % 3", 1)]
     [InlineData("10 % 3", 1)]
     [InlineData("7 % 4", 3)]
-    public void MathExpression_CompileThenInvoke_Int32_HasModulus_ExpectedValue(string mathString, int expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int32_HasModulus_ExpectedValue(string mathString, int expectedValue)
     {
-        using var expression = new MathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<int>();
@@ -54,9 +54,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 ** 3", 8)]
     [InlineData("2 ** 4", 16)]
     [InlineData("3 ** 3", 27)]
-    public void MathExpression_CompileThenInvoke_Int32_HasPower_ExpectedValue(string mathString, int expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int32_HasPower_ExpectedValue(string mathString, int expectedValue)
     {
-        using var expression = new MathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<int>();
@@ -71,9 +71,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("x + y", 5, 3, 8)]
     [InlineData("x * y", 5, 3, 15)]
     [InlineData("x - y", 5, 3, 2)]
-    public void MathExpression_CompileThenInvoke_Int32_HasVariables_ExpectedValue(string mathString, int x, int y, int expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int32_HasVariables_ExpectedValue(string mathString, int x, int y, int expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         dynamic parameters = new ExpandoObject();
@@ -96,9 +96,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 * 5 / 2", 2L * 5 / 2)]
     [InlineData("1000000000 * 2", 1000000000L * 2)]
     [InlineData("-20", -20L)]
-    public void MathExpression_CompileThenInvoke_Int64_ExpectedValue(string mathString, long expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int64_ExpectedValue(string mathString, long expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<long>();
@@ -112,7 +112,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [Theory]
     [InlineData("x + y", 5000000000L, 3000000000L, 8000000000L)]
     [InlineData("x - y", 5000000000L, 3000000000L, 2000000000L)]
-    public void MathExpression_CompileThenInvoke_Int64_HasVariables_ExpectedValue(string mathString, long x, long y, long expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int64_HasVariables_ExpectedValue(string mathString, long x, long y, long expectedValue)
     {
         testOutputHelper.WriteLine($"{mathString} = {expectedValue}");
         testOutputHelper.WriteLine($"x = {x}, y = {y}");
@@ -134,9 +134,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("10.0 / 4.0", 10.0f / 4.0f)]
     [InlineData("-20.5", -20.5f)]
     [InlineData("2.5 * 2.0", 2.5f * 2.0f)]
-    public void MathExpression_CompileThenInvoke_Single_ExpectedValue(string mathString, float expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Single_ExpectedValue(string mathString, float expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<float>();
@@ -150,7 +150,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [Theory]
     [InlineData("x + y", 2.5f, 1.5f, 4.0f)]
     [InlineData("x * y", 2.5f, 2.0f, 5.0f)]
-    public void MathExpression_CompileThenInvoke_Single_HasVariables_ExpectedValue(string mathString, float x, float y, float expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Single_HasVariables_ExpectedValue(string mathString, float x, float y, float expectedValue)
     {
         testOutputHelper.WriteLine($"{mathString} = {expectedValue}");
         testOutputHelper.WriteLine($"x = {x}, y = {y}");
@@ -172,9 +172,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("10.0 / 4.0", 2.5)]
     [InlineData("-20.5", -20.5)]
     [InlineData("2.5 * 2.0", 5.0)]
-    public void MathExpression_CompileThenInvoke_Half_ExpectedValue(string mathString, double expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Half_ExpectedValue(string mathString, double expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<Half>();
@@ -188,7 +188,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [Theory]
     [InlineData("x + y", 2.5, 1.5, 4.0)]
     [InlineData("x * y", 2.5, 2.0, 5.0)]
-    public void MathExpression_CompileThenInvoke_Half_HasVariables_ExpectedValue(string mathString, double x, double y, double expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Half_HasVariables_ExpectedValue(string mathString, double x, double y, double expectedValue)
     {
         testOutputHelper.WriteLine($"{mathString} = {expectedValue}");
         testOutputHelper.WriteLine($"x = {x}, y = {y}");
@@ -214,9 +214,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", (byte)(2 + 5))]
     [InlineData("10 * 2", (byte)(10 * 2))]
     [InlineData("20 - 5", (byte)(20 - 5))]
-    public void MathExpression_CompileThenInvoke_Byte_ExpectedValue(string mathString, byte expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Byte_ExpectedValue(string mathString, byte expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<byte>();
@@ -235,9 +235,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", 2u + 5u)]
     [InlineData("10 * 2", 10u * 2u)]
     [InlineData("20 - 5", 20u - 5u)]
-    public void MathExpression_CompileThenInvoke_UInt32_ExpectedValue(string mathString, uint expectedValue)
+    public void FastMathExpression_CompileThenInvoke_UInt32_ExpectedValue(string mathString, uint expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<uint>();
@@ -256,9 +256,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", 2UL + 5UL)]
     [InlineData("10 * 2", 10UL * 2UL)]
     [InlineData("5000000000 + 3000000000", 5000000000UL + 3000000000UL)]
-    public void MathExpression_CompileThenInvoke_UInt64_ExpectedValue(string mathString, ulong expectedValue)
+    public void FastMathExpression_CompileThenInvoke_UInt64_ExpectedValue(string mathString, ulong expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<ulong>();
@@ -277,9 +277,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", (short)(2 + 5))]
     [InlineData("10 * 2", (short)(10 * 2))]
     [InlineData("-20", (short)-20)]
-    public void MathExpression_CompileThenInvoke_Int16_ExpectedValue(string mathString, short expectedValue)
+    public void FastMathExpression_CompileThenInvoke_Int16_ExpectedValue(string mathString, short expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<short>();
@@ -298,9 +298,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", (ushort)(2 + 5))]
     [InlineData("10 * 2", (ushort)(10 * 2))]
     [InlineData("100 / 5", (ushort)(100 / 5))]
-    public void MathExpression_CompileThenInvoke_UInt16_ExpectedValue(string mathString, ushort expectedValue)
+    public void FastMathExpression_CompileThenInvoke_UInt16_ExpectedValue(string mathString, ushort expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<ushort>();
@@ -319,9 +319,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 + 5", (sbyte)(2 + 5))]
     [InlineData("10 - 5", (sbyte)(10 - 5))]
     [InlineData("-20", (sbyte)-20)]
-    public void MathExpression_CompileThenInvoke_SByte_ExpectedValue(string mathString, sbyte expectedValue)
+    public void FastMathExpression_CompileThenInvoke_SByte_ExpectedValue(string mathString, sbyte expectedValue)
     {
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<sbyte>();
@@ -342,11 +342,11 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("999999999999999999999999999999 - 1", "999999999999999999999999999998")]
     [InlineData("100000000000000000000 / 50000000000000000000", "2")]
     [InlineData("-123456789012345678901234567890", "-123456789012345678901234567890")]
-    public void MathExpression_CompileThenInvoke_BigInteger_ExpectedValue(string mathString, string expectedValueString)
+    public void FastMathExpression_CompileThenInvoke_BigInteger_ExpectedValue(string mathString, string expectedValueString)
     {
         var expectedValue = BigInteger.Parse(expectedValueString);
 
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<BigInteger>();
@@ -362,9 +362,9 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("1000000000000000000 % 3", 1)]
     [InlineData("123456789012345678901234567894 % 7", 4)]
     [InlineData("123456789012345678901234567894 % a", 4)]
-    public void MathExpression_CompileThenInvoke_BigInteger_HasModulus_ExpectedValue(string mathString, long expectedValue)
+    public void FastMathExpression_CompileThenInvoke_BigInteger_HasModulus_ExpectedValue(string mathString, long expectedValue)
     {
-        using var expression = new MathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var parameters = new Dictionary<string, object>
@@ -383,11 +383,11 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("2 ** 100", "1267650600228229401496703205376")]
     [InlineData("a ** 30", "1000000000000000000000000000000")]
     [InlineData("2 ** a ** 2", "1267650600228229401496703205376")]
-    public void MathExpression_CompileThenInvoke_BigInteger_HasPower_ExpectedValue(string mathString, string expectedValueString)
+    public void FastMathExpression_CompileThenInvoke_BigInteger_HasPower_ExpectedValue(string mathString, string expectedValueString)
     {
         var expectedValue = BigInteger.Parse(expectedValueString);
 
-        using var expression = new MathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, _programmingContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         dynamic parameters = new ExpandoObject();
@@ -408,7 +408,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("x + y", "123456789012345678901234567890", "987654321098765432109876543210", "1111111110111111111011111111100")]
     [InlineData("x * y", "1000000000000000000", "1000000000000000000", "1000000000000000000000000000000000000")]
     [InlineData("x - y", "999999999999999999999999999999", "1", "999999999999999999999999999998")]
-    public void MathExpression_CompileThenInvoke_BigInteger_HasVariables_ExpectedValue(string mathString, string xString, string yString, string expectedValueString)
+    public void FastMathExpression_CompileThenInvoke_BigInteger_HasVariables_ExpectedValue(string mathString, string xString, string yString, string expectedValueString)
     {
         var x = BigInteger.Parse(xString);
         var y = BigInteger.Parse(yString);
@@ -434,11 +434,11 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     [InlineData("0xFFFFFFFFFFFFFFFF + 1", "18446744073709551616")]
     [InlineData("0b1111111111111111111111111111111111111111111111111111111111111111 + 1", "18446744073709551616")]
     [InlineData("0o1777777777777777777777 + 1", "18446744073709551616")]
-    public void MathExpression_CompileThenInvoke_BigInteger_HasDifferentNotations_ExpectedValue(string mathString, string expectedValueString)
+    public void FastMathExpression_CompileThenInvoke_BigInteger_HasDifferentNotations_ExpectedValue(string mathString, string expectedValueString)
     {
         var expectedValue = BigInteger.Parse(expectedValueString);
 
-        using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<BigInteger>();
@@ -454,7 +454,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     #region INumberBase Function Compilation Tests
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasInt32Function_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasInt32Function_ExpectedValue()
     {
         Func<int, int> square = x => x * x;
         Func<int, int, int> add = (a, b) => a + b;
@@ -468,14 +468,14 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
             { "y", 3 }
         };
 
-        var fn = "square(x) + add(y, 10)".Compile<Dictionary<string, object>, int>(dict, context);
+        var fn = "square(x) + add(y, 10)".CompileFast<Dictionary<string, object>, int>(dict, context);
         var result = fn(dict);
 
         Assert.Equal(38, result); // 25 + 13
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasBigIntegerFunction_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasBigIntegerFunction_ExpectedValue()
     {
         Func<BigInteger, BigInteger> square = x => x * x;
         Func<BigInteger, BigInteger, BigInteger> multiply = (a, b) => a * b;
@@ -489,7 +489,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
             { "y", new BigInteger(100) }
         };
 
-        var fn = "multiply(square(x), y)".Compile<Dictionary<string, object>, BigInteger>(dict, context);
+        var fn = "multiply(square(x), y)".CompileFast<Dictionary<string, object>, BigInteger>(dict, context);
         var result = fn(dict);
 
         var expected = BigInteger.Parse("100000000000000000000000000");
@@ -497,7 +497,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasLongFunctionWithVariables_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasLongFunctionWithVariables_ExpectedValue()
     {
         Func<long, long, long> max = (a, b) => Math.Max(a, b);
         Func<long, long, long> min = (a, b) => Math.Min(a, b);
@@ -509,7 +509,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
         parameters.x = 500L;
         parameters.y = 2000L;
 
-        using var expression = new MathExpression("max(x, min(y, 1000))", context, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression("max(x, min(y, 1000))", context, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<ExpandoObject, long>(parameters);
@@ -524,7 +524,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasFloatFunctionChain_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasFloatFunctionChain_ExpectedValue()
     {
         Func<float, float> abs = x => Math.Abs(x);
         Func<float, float, float> pow = (a, b) => (float)Math.Pow(a, b);
@@ -538,14 +538,14 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
             { "y", -3f }
         };
 
-        var fn = "pow(abs(x), 2) + abs(y)".Compile<Dictionary<string, object>, float>(dict, context);
+        var fn = "pow(abs(x), 2) + abs(y)".CompileFast<Dictionary<string, object>, float>(dict, context);
         var result = fn(dict);
 
         Assert.Equal(28f, result, precision: 5); // 25 + 3
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasVariadicBigIntegerFunction_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasVariadicBigIntegerFunction_ExpectedValue()
     {
         Func<BigInteger[], BigInteger> sum = args =>
         {
@@ -563,7 +563,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
         parameters.y = BigInteger.Parse("200000000000000000");
         parameters.z = BigInteger.Parse("300000000000000000");
 
-        using var expression = new MathExpression("sum(x, y, z, 1000)", context, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression("sum(x, y, z, 1000)", context, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<ExpandoObject, BigInteger>(parameters);
@@ -574,7 +574,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasMixedINumberBaseFunctions_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasMixedINumberBaseFunctions_ExpectedValue()
     {
         Func<int, int> doubleInt = x => x * 2;
         Func<BigInteger, BigInteger> squareBig = x => x * x;
@@ -585,8 +585,8 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
         var dictInt = new Dictionary<string, object> { { "x", 15 } };
         var dictBig = new Dictionary<string, object> { { "y", BigInteger.Parse("1000000000") } };
 
-        var fnInt = "doubleInt(x) + 10".Compile<Dictionary<string, object>, int>(dictInt, context);
-        var fnBig = "squareBig(y)".Compile<Dictionary<string, object>, BigInteger>(dictBig, context);
+        var fnInt = "doubleInt(x) + 10".CompileFast<Dictionary<string, object>, int>(dictInt, context);
+        var fnBig = "squareBig(y)".CompileFast<Dictionary<string, object>, BigInteger>(dictBig, context);
 
         var resultInt = fnInt(dictInt);
         var resultBig = fnBig(dictBig);
@@ -596,7 +596,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasBigIntegerCryptographyFunction_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasBigIntegerCryptographyFunction_ExpectedValue()
     {
         Func<BigInteger, BigInteger, BigInteger, BigInteger> modPow = static (value, exponent, modulus) =>
             BigInteger.ModPow(value, exponent, modulus);
@@ -615,7 +615,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
             { "e", new BigInteger(65537) }
         };
 
-        var fn = "modPow(message, e, n)".Compile<Dictionary<string, object>, BigInteger>(dict, context);
+        var fn = "modPow(message, e, n)".CompileFast<Dictionary<string, object>, BigInteger>(dict, context);
         var encrypted = fn(dict);
 
         var expected = BigInteger.ModPow(new BigInteger(123456789), new BigInteger(65537), n);
@@ -623,7 +623,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasByteFunction_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasByteFunction_ExpectedValue()
     {
         Func<byte, byte, byte> max = (a, b) => a > b ? a : b;
         
@@ -634,7 +634,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
         p.x = (byte)100;
         p.y = (byte)25;
 
-        using var expression = new MathExpression("max(x, max(y, 50))", context, CultureInfo.InvariantCulture);
+        using var expression = new FastMathExpression("max(x, max(y, 50))", context, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
 
         var fn = expression.Compile<ExpandoObject, byte>(p);
@@ -644,7 +644,7 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasHalfFunctionWithDictionary_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasHalfFunctionWithDictionary_ExpectedValue()
     {
         Func<Half, Half, Half> add = (a, b) => (Half)((double)a + (double)b);
         
@@ -657,14 +657,14 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
             { "y", (Half)3.5 }
         };
 
-        var fn = "add(x, y) + add(x, x)".Compile<Dictionary<string, object>, Half>(dict, context);
+        var fn = "add(x, y) + add(x, x)".CompileFast<Dictionary<string, object>, Half>(dict, context);
         var result = fn(dict);
 
         Assert.Equal((Half)11.0, result); // (2.5 + 3.5) + (2.5 + 2.5)
     }
 
     [Fact]
-    public void MathExpression_CompileThenInvoke_HasComplexINumberBaseExpressions_ExpectedValue()
+    public void FastMathExpression_CompileThenInvoke_HasComplexINumberBaseExpressions_ExpectedValue()
     {
         Func<int, int, int, int> triple = (a, b, c) => a + b + c;
         Func<long, long> negate = x => -x;
@@ -680,8 +680,8 @@ public partial class MathExpressionTests_Number(ITestOutputHelper testOutputHelp
         };
         var dictLong = new Dictionary<string, object> { { "a", 50L } };
 
-        var fnInt = "triple(x, y, z) * 2".Compile<Dictionary<string, object>, int>(dictInt, context);
-        var fnLong = "negate(a) + 100".Compile<Dictionary<string, object>, long>(dictLong, context);
+        var fnInt = "triple(x, y, z) * 2".CompileFast<Dictionary<string, object>, int>(dictInt, context);
+        var fnLong = "negate(a) + 100".CompileFast<Dictionary<string, object>, long>(dictLong, context);
 
         var resultInt = fnInt(dictInt);
         var resultLong = fnLong(dictLong);

--- a/MathEvaluation.FastExpressionCompiler.Tests/MathEvaluation.FastExpressionCompiler.Tests.csproj
+++ b/MathEvaluation.FastExpressionCompiler.Tests/MathEvaluation.FastExpressionCompiler.Tests.csproj
@@ -15,11 +15,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MathEvaluation.FastExpressionCompiler/Extensions/StringExtensions.cs
+++ b/MathEvaluation.FastExpressionCompiler/Extensions/StringExtensions.cs
@@ -9,6 +9,11 @@ namespace MathEvaluation.Extensions;
 /// </summary>
 public static class StringExtensions
 {
+    /// <inheritdoc cref="MathExpression.Compile{T, TResult}(T)" />
+    public static Func<T, TResult> CompileFast<T, TResult>(this string mathString, T parameters, MathContext? context = null, IFormatProvider? provider = null)
+        where TResult : struct, INumberBase<TResult>
+        => new MathExpression(mathString, context, provider).Compile<T, TResult>(parameters);
+
     /// <inheritdoc cref="MathExpression.Compile{T}(T)" />
     public static Func<T, double> CompileFast<T>(this string mathString, T parameters, MathContext? context = null, IFormatProvider? provider = null)
         => new FastMathExpression(mathString, context, provider).Compile(parameters);

--- a/MathEvaluation.FastExpressionCompiler/MathEvaluation.FastExpressionCompiler.csproj
+++ b/MathEvaluation.FastExpressionCompiler/MathEvaluation.FastExpressionCompiler.csproj
@@ -26,7 +26,7 @@ Multi-targets .NET 7, .NET 8, .NET 9, and .NET 10 for optimal performance on eac
 .NET Standard 2.1 compatible in versions prior to 3.0.0
         </PackageReleaseNotes>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.0.1</Version>
+        <Version>3.0.2</Version>
         <PackageId>MathEvaluator.FastExpressionCompiler</PackageId>
         <Product>MathEvaluator.FastExpressionCompiler</Product>
         <PackageIcon>logo.png</PackageIcon>

--- a/MathEvaluation.FastExpressionCompiler/MathEvaluation.FastExpressionCompiler.csproj
+++ b/MathEvaluation.FastExpressionCompiler/MathEvaluation.FastExpressionCompiler.csproj
@@ -83,7 +83,7 @@ Multi-targets .NET 7, .NET 8, .NET 9, and .NET 10 for optimal performance on eac
 
     <ItemGroup>
       <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
-      <PackageReference Include="MathEvaluator" Version="3.0.1" />
+      <PackageReference Include="MathEvaluator" Version="3.0.2" />
     </ItemGroup>
 
 </Project>

--- a/MathEvaluation.Tests/Compilation/DecimalDotNetStandardMathContextTests.cs
+++ b/MathEvaluation.Tests/Compilation/DecimalDotNetStandardMathContextTests.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand
 

--- a/MathEvaluation.Tests/Compilation/DotNetStandardMathContextTests.cs
+++ b/MathEvaluation.Tests/Compilation/DotNetStandardMathContextTests.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand
 

--- a/MathEvaluation.Tests/Compilation/MathExpressionTests.Compile.cs
+++ b/MathEvaluation.Tests/Compilation/MathExpressionTests.Compile.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Compilation;
 
@@ -432,6 +431,42 @@ public partial class MathExpressionTests(ITestOutputHelper testOutputHelper)
     [InlineData("⌈2 + 3.5⌉", 6d)]
     [InlineData("3 + 2⌈2 + 3.5⌉  ^2", 3 + 2 * 6d * 6d)]
     public void MathExpression_CompileThenInvoke_HasCeiling_ExpectedValue(string mathString, double expectedValue)
+    {
+        using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
+        expression.Evaluating += SubscribeToEvaluating;
+
+        var fn = expression.Compile();
+        var value = fn();
+
+        testOutputHelper.WriteLine($"result: {value}");
+
+        Assert.Equal(expectedValue, value);
+    }
+
+    [Theory]
+    [InlineData("pos(5)", 5d)]
+    [InlineData("Pos(5)", 5d)]
+    [InlineData("POS(5)", 5d)]
+    [InlineData("pos(-3)", 0d)]
+    [InlineData("pos(0)", 0d)]
+    [InlineData("pos(-20.3)", 0d)]
+    [InlineData("pos(20.3)", 20.3d)]
+    [InlineData("-pos(5)", -5d)]
+    [InlineData("3pos(-5)", 0d)]
+    [InlineData("3pos(5)", 15d)]
+    [InlineData("2 / pos(5) / 2 * 5", 2d / 5 / 2 * 5)]
+    [InlineData("pos(2 + (5 - 1))", 2 + (5 - 1))]
+    [InlineData("2(5 - pos(-1))", 2 * (5 - 0))]
+    [InlineData("2(5 - pos(1))", 2 * (5 - 1))]
+    [InlineData("pos(5 - 1)(3 + 1)", 4d * 4d)]
+    [InlineData("(3 + 1)*pos(5 - 1)", (3 + 1) * 4d)]
+    [InlineData("6 + pos(-4)", 6d)]
+    [InlineData("6 + pos(4)", 10d)]
+    [InlineData("6 + - pos(4)", 2d)]
+    [InlineData("pos(sin3)", 0.1411200080598672d)]
+    [InlineData("pos(sin-3)", 0d)]
+    [InlineData("3 + 2pos(2 + 3.5)^2", 3 + 2 * 5.5d * 5.5d)]
+    public void MathExpression_CompileThenInvoke_HasPos_ExpectedValue(string mathString, double expectedValue)
     {
         using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;

--- a/MathEvaluation.Tests/Compilation/MathExpressionTests_Complex.Compile.cs
+++ b/MathEvaluation.Tests/Compilation/MathExpressionTests_Complex.Compile.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Compilation;
 

--- a/MathEvaluation.Tests/Compilation/MathExpressionTests_Decimal.Compile.cs
+++ b/MathEvaluation.Tests/Compilation/MathExpressionTests_Decimal.Compile.cs
@@ -1,7 +1,6 @@
 ﻿using MathEvaluation.Context;
 using MathEvaluation.Extensions;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Compilation;
 
@@ -390,6 +389,42 @@ public partial class MathExpressionTests_Decimal(ITestOutputHelper testOutputHel
     [InlineData("⌈2 + 3.5⌉", 6d)]
     [InlineData("3 + 2⌈2 + 3.5⌉  ^2", 3 + 2 * 6d * 6d)]
     public void MathExpression_CompileDecimalThenInvoke_HasCeiling_ExpectedValue(string mathString, double expectedValue)
+    {
+        using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
+        expression.Evaluating += SubscribeToEvaluating;
+
+        var fn = expression.CompileDecimal();
+        var value = fn();
+
+        testOutputHelper.WriteLine($"result: {value}");
+
+        Assert.Equal((decimal)expectedValue, value);
+    }
+
+    [Theory]
+    [InlineData("pos(5)", 5d)]
+    [InlineData("Pos(5)", 5d)]
+    [InlineData("POS(5)", 5d)]
+    [InlineData("pos(-3)", 0d)]
+    [InlineData("pos(0)", 0d)]
+    [InlineData("pos(-20.3)", 0d)]
+    [InlineData("pos(20.3)", 20.3d)]
+    [InlineData("-pos(5)", -5d)]
+    [InlineData("3pos(-5)", 0d)]
+    [InlineData("3pos(5)", 15d)]
+    [InlineData("2 / pos(5) / 2 * 5", 2d / 5 / 2 * 5)]
+    [InlineData("pos(2 + (5 - 1))", 2 + (5 - 1))]
+    [InlineData("2(5 - pos(-1))", 2 * (5 - 0))]
+    [InlineData("2(5 - pos(1))", 2 * (5 - 1))]
+    [InlineData("pos(5 - 1)(3 + 1)", 4d * 4d)]
+    [InlineData("(3 + 1)*pos(5 - 1)", (3 + 1) * 4d)]
+    [InlineData("6 + pos(-4)", 6d)]
+    [InlineData("6 + pos(4)", 10d)]
+    [InlineData("6 + - pos(4)", 2d)]
+    [InlineData("pos(sin3)", 0.1411200080598672d)]
+    [InlineData("pos(sin-3)", 0d)]
+    [InlineData("3 + 2pos(2 + 3.5)^2", 3 + 2 * 5.5d * 5.5d)]
+    public void MathExpression_CompileDecimalThenInvoke_HasPos_ExpectedValue(string mathString, double expectedValue)
     {
         using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;

--- a/MathEvaluation.Tests/Evaluation/DecimalDotNetStandardMathContextTests.cs
+++ b/MathEvaluation.Tests/Evaluation/DecimalDotNetStandardMathContextTests.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using MathEvaluation.Parameters;
 using System.Globalization;
-using Xunit.Abstractions;
 
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand

--- a/MathEvaluation.Tests/Evaluation/DotNetStandardMathContextTests.cs
+++ b/MathEvaluation.Tests/Evaluation/DotNetStandardMathContextTests.cs
@@ -3,7 +3,6 @@ using MathEvaluation.Extensions;
 using MathEvaluation.Parameters;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 
 // ReSharper disable EqualExpressionComparison
 // ReSharper disable RedundantLogicalConditionalExpressionOperand

--- a/MathEvaluation.Tests/Evaluation/MathExpressionTests.Evaluate.cs
+++ b/MathEvaluation.Tests/Evaluation/MathExpressionTests.Evaluate.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using MathEvaluation.Parameters;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Evaluation;
 
@@ -65,7 +64,7 @@ public partial class MathExpressionTests(ITestOutputHelper testOutputHelper)
 
         using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
-        
+
         var value = expression.Evaluate();
 
         Assert.Equal(10 + 7, value);
@@ -89,9 +88,9 @@ public partial class MathExpressionTests(ITestOutputHelper testOutputHelper)
         var mathString = "0o12 + 0O7";
         using var expression = new MathExpression(mathString, null, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;
-        
+
         var value = expression.Evaluate();
-        
+
         Assert.Equal(10 + 7, value);
     }
 
@@ -465,6 +464,40 @@ public partial class MathExpressionTests(ITestOutputHelper testOutputHelper)
     [InlineData("⌈2 + 3.5⌉", 6d)]
     [InlineData("3 + 2⌈2 + 3.5⌉  ^2", 3 + 2 * 6d * 6d)]
     public void MathExpression_Evaluate_HasCeiling_ExpectedValue(string mathString, double expectedValue)
+    {
+        using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
+        expression.Evaluating += SubscribeToEvaluating;
+
+        var value = expression.Evaluate();
+
+        Assert.Equal(expectedValue, value);
+    }
+
+    [Theory]
+    [InlineData("pos(5)", 5d)]
+    [InlineData("Pos(5)", 5d)]
+    [InlineData("POS(5)", 5d)]
+    [InlineData("pos(-3)", 0d)]
+    [InlineData("pos(0)", 0d)]
+    [InlineData("pos(-20.3)", 0d)]
+    [InlineData("pos(20.3)", 20.3d)]
+    [InlineData("-pos(5)", -5d)]
+    [InlineData("3pos(-5)", 0d)]
+    [InlineData("3pos(5)", 15d)]
+    [InlineData("2 / pos(5) / 2 * 5", 2d / 5 / 2 * 5)]
+    [InlineData("pos(2 + (5 - 1))", 2 + (5 - 1))]
+    [InlineData("2(5 - pos(-1))", 2 * (5 - 0))]
+    [InlineData("2(5 - pos(1))", 2 * (5 - 1))]
+    [InlineData("pos(5 - 1)(3 + 1)", 4d * 4d)]
+    [InlineData("(3 + 1)*pos(5 - 1)", (3 + 1) * 4d)]
+    [InlineData("(3 + 1)*pos(-(1 - 5))", 16d)]
+    [InlineData("6 + pos(-4)", 6d)]
+    [InlineData("6 + pos(4)", 10d)]
+    [InlineData("6 + - pos(4)", 2d)]
+    [InlineData("pos(sin3)", 0.1411200080598672d)]
+    [InlineData("pos(sin-3)", 0d)]
+    [InlineData("3 + 2pos(2 + 3.5)^2", 3 + 2 * 5.5d * 5.5d)]
+    public void MathExpression_Evaluate_HasPos_ExpectedValue(string mathString, double expectedValue)
     {
         using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;

--- a/MathEvaluation.Tests/Evaluation/MathExpressionTests_Complex.Evaluate.cs
+++ b/MathEvaluation.Tests/Evaluation/MathExpressionTests_Complex.Evaluate.cs
@@ -3,7 +3,6 @@ using MathEvaluation.Extensions;
 using MathEvaluation.Parameters;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Evaluation;
 

--- a/MathEvaluation.Tests/Evaluation/MathExpressionTests_Decimal.Evaluate.cs
+++ b/MathEvaluation.Tests/Evaluation/MathExpressionTests_Decimal.Evaluate.cs
@@ -2,7 +2,6 @@
 using MathEvaluation.Extensions;
 using MathEvaluation.Parameters;
 using System.Globalization;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Evaluation;
 
@@ -391,6 +390,40 @@ public partial class MathExpressionTests_Decimal(ITestOutputHelper testOutputHel
     [InlineData("⌈2 + 3.5⌉", 6d)]
     [InlineData("3 + 2⌈2 + 3.5⌉  ^2", 3 + 2 * 6d * 6d)]
     public void MathExpression_EvaluateDecimal_HasCeiling_ExpectedValue(string mathString, double expectedValue)
+    {
+        using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
+        expression.Evaluating += SubscribeToEvaluating;
+
+        var value = expression.EvaluateDecimal();
+
+        Assert.Equal((decimal)expectedValue, value);
+    }
+
+    [Theory]
+    [InlineData("pos(5)", 5d)]
+    [InlineData("Pos(5)", 5d)]
+    [InlineData("POS(5)", 5d)]
+    [InlineData("pos(-3)", 0d)]
+    [InlineData("pos(0)", 0d)]
+    [InlineData("pos(-20.3)", 0d)]
+    [InlineData("pos(20.3)", 20.3d)]
+    [InlineData("-pos(5)", -5d)]
+    [InlineData("3pos(-5)", 0d)]
+    [InlineData("3pos(5)", 15d)]
+    [InlineData("2 / pos(5) / 2 * 5", 2d / 5 / 2 * 5)]
+    [InlineData("pos(2 + (5 - 1))", 2 + (5 - 1))]
+    [InlineData("2(5 - pos(-1))", 2 * (5 - 0))]
+    [InlineData("2(5 - pos(1))", 2 * (5 - 1))]
+    [InlineData("pos(5 - 1)(3 + 1)", 4d * 4d)]
+    [InlineData("(3 + 1)*pos(5 - 1)", (3 + 1) * 4d)]
+    [InlineData("(3 + 1)*pos(-(1 - 5))", 16d)]
+    [InlineData("6 + pos(-4)", 6d)]
+    [InlineData("6 + pos(4)", 10d)]
+    [InlineData("6 + - pos(4)", 2d)]
+    [InlineData("pos(sin3)", 0.1411200080598672d)]
+    [InlineData("pos(sin-3)", 0d)]
+    [InlineData("3 + 2pos(2 + 3.5)^2", 3 + 2 * 5.5d * 5.5d)]
+    public void MathExpression_EvaluateDecimal_HasPos_ExpectedValue(string mathString, double expectedValue)
     {
         using var expression = new MathExpression(mathString, _scientificContext, CultureInfo.InvariantCulture);
         expression.Evaluating += SubscribeToEvaluating;

--- a/MathEvaluation.Tests/Evaluation/MathExpressionTests_Number.Evaluate.cs
+++ b/MathEvaluation.Tests/Evaluation/MathExpressionTests_Number.Evaluate.cs
@@ -3,7 +3,6 @@ using MathEvaluation.Extensions;
 using System.Dynamic;
 using System.Globalization;
 using System.Numerics;
-using Xunit.Abstractions;
 
 namespace MathEvaluation.Tests.Evaluation;
 

--- a/MathEvaluation.Tests/MathEvaluation.Tests.csproj
+++ b/MathEvaluation.Tests/MathEvaluation.Tests.csproj
@@ -15,11 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MathEvaluation.Tests/MathExpressionTests.cs
+++ b/MathEvaluation.Tests/MathExpressionTests.cs
@@ -1,6 +1,4 @@
-﻿using Xunit.Abstractions;
-
-namespace MathEvaluation.Tests;
+﻿namespace MathEvaluation.Tests;
 
 public class MathExpressionTests(ITestOutputHelper testOutputHelper)
 {

--- a/MathEvaluation/Context/Decimal/DecimalScientificMathContext.cs
+++ b/MathEvaluation/Context/Decimal/DecimalScientificMathContext.cs
@@ -30,6 +30,12 @@ public class DecimalScientificMathContext : ScientificMathContext
         BindFunction<decimal>(absFn, "Abs");
         BindFunction<decimal>(absFn, "ABS");
 
+        static decimal posFn(decimal v) => Math.Max(v, 0m);
+
+        BindFunction<decimal>(posFn, "pos");
+        BindFunction<decimal>(posFn, "Pos");
+        BindFunction<decimal>(posFn, "POS");
+
         static decimal ceilingFn(decimal v) => Math.Ceiling(v);
 
         BindFunction<decimal>(ceilingFn, '⌈', '⌉');

--- a/MathEvaluation/Context/ScientificMathContext.cs
+++ b/MathEvaluation/Context/ScientificMathContext.cs
@@ -55,6 +55,12 @@ public class ScientificMathContext : MathContext
         BindFunction<double>(absFn, "Abs");
         BindFunction<double>(absFn, "ABS");
 
+        static double posFn(double v) => Math.Max(v, 0d);
+
+        BindFunction<double>(posFn, "pos");
+        BindFunction<double>(posFn, "Pos");
+        BindFunction<double>(posFn, "POS");
+
         static double ceilingFn(double v) => Math.Ceiling(v);
 
         BindFunction<double>(ceilingFn, '⌈', '⌉');

--- a/MathEvaluation/MathEvaluation.csproj
+++ b/MathEvaluation/MathEvaluation.csproj
@@ -25,7 +25,7 @@ Multi-targets .NET 7, .NET 8, .NET 9, and .NET 10 for optimal performance on eac
 .NET Standard 2.1 compatible in versions prior to 3.0.0
         </PackageReleaseNotes>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <Version>3.0.1</Version>
+        <Version>3.0.2</Version>
         <PackageId>MathEvaluator</PackageId>
         <Product>MathEvaluator</Product>
         <PackageIcon>logo.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ Example of compilation with a Dictionary as a parameter (Added in version [2.3.0
     fn = "x1 + Math.Sin(x3) * Math.Cos(x4)"
         .Compile(dict, new DotNetStandardMathContext());
 
+**MathContext** class defines the mathematical "language" available in expressions - what operators, functions, and constants can be used. It's reusable across multiple evaluations and determines syntax rules (e.g., whether to use `^` or `**` for exponentiation, which functions like `sin`, `cos`, `sqrt` are available).
+
+**MathParameters** class provides the actual values and custom implementations for a specific evaluation. It supplies variable values and function delegates that are used when evaluating a particular expression.
+
 ## How to debug or log
 
 Added in version [2.1.0](https://github.com/AntonovAnton/math.evaluation/releases/tag/2.1.0)
@@ -310,6 +314,7 @@ For .NET 7 and higher, MathEvaluator supports any numeric type that implements `
 | Modulus | mod, Mod, MOD, modulo, Modulo, or MODULO | 100 |
 | Floor Division  | // | 100 |
 | Absolute  | \| \|, abs, Abs, ABS | 200 |
+| Positive part | pos, Pos, POS | 200 |
 | Ceiling | ⌈ ⌉, ceil, Ceil, CEIL | 200 |
 | Floor | ⌊ ⌋, floor, Floor, FLOOR | 200 |
 | Square root | √, sqrt, Sqrt, SQRT | 200 |
@@ -377,14 +382,13 @@ For .NET 7 and higher, MathEvaluator supports any numeric type that implements `
 **Example using DotNetMathContext:**
 
     // BigInteger cryptography example (.NET 7+)
-    var p = BigInteger.Parse("2305843009213693951");
-    var q = BigInteger.Parse("2305843009213693967");
-    var n = p * q;
-
     var context = new DotNetMathContext();
+    
+    var p = "2305843009213693951";
+    var q = "2305843009213693967";
 
-    var encrypted = "BigInteger.ModPow(message, e, n)"
-        .Evaluate<BigInteger>(new { message = 123456789, e = 65537, n }, context);
+    var encrypted = "BigInteger.ModPow(message, e, p * q)"
+        .Evaluate<BigInteger>(new { message = 123456789, e = 65537, p, q }, context);
 
     // Using new Math functions
     var result = "Math.Log2(1024) + Math.Tau / 2".Evaluate(null, context);
@@ -392,6 +396,22 @@ For .NET 7 and higher, MathEvaluator supports any numeric type that implements `
 
     // Int128 calculations
     var bigCalc = "x + y".Evaluate<Int128>(new { x = Int128.MaxValue / 2, y = Int128.One }, context);
+
+## Error Handling
+
+When an invalid mathematical expression is provided, the library throws a `MathExpressionException` with a descriptive error message that includes the position of the error. This helps you quickly identify and fix issues in your expressions.
+
+Example:
+
+    try
+    {
+        "12 + abs()".Evaluate(context: new ScientificMathContext());
+    }
+    catch (MathExpressionException ex)
+    {
+        Console.WriteLine(ex.Message);
+        // Output: Error of evaluating the expression. The operand is not recognizable. Invalid token at position 9.
+    }
 
 ## Contributing
 Contributions are welcome! Please fork the repository and submit pull requests for any enhancements or bug fixes.


### PR DESCRIPTION
Added support for the pos (positive part) function (pos, Pos, POS) to both ScientificMathContext and DecimalScientificMathContext, returning max(x, 0). Comprehensive tests for pos() were added across all evaluation and compilation modes. Introduced a generic CompileFast<T, TResult>() extension for string expressions, enabling direct compilation to any INumberBase<TResult> type. Updated README and function/operator docs to include pos(). Bumped version to 3.0.2. Minor formatting and README improvements.